### PR TITLE
Fix default lsp sources name

### DIFF
--- a/lua/gtd/init.lua
+++ b/lua/gtd/init.lua
@@ -49,8 +49,8 @@ gtd.Event = {
 
 gtd.config = Config.new({
   sources = {
-    { name = 'lsp_definitions' },
-    { name = 'lsp_type_definitions' },
+    { name = 'lsp_definition' },
+    { name = 'lsp_type_definition' },
     { name = 'lsp_implementation' },
     { name = 'findup' },
   },


### PR DESCRIPTION
Thank you for the amazing plugin.

I am using nvim-gtd with the default settings.
In lazy.nvim, I have it installed as follows:
```lua
  {
    "hrsh7th/nvim-gtd",
    event = { "VeryLazy" },
    config = function()
      require("gtd").setup({})
    end,
  },
```


It seems that since [this commit](https://github.com/tkmpypy/nvim-gtd/commit/d8992e6502b15d78eebce71230fad693fea1d288#diff-72ddb474cfdce1a89b802c51a4562f34e8becb884c5215b3d1deeb8ef19b77c0R281-R282), the LSP source has been returning Nothing found.
NOTE: The regular vim.lsp.definition() works fine.

Upon investigation, it appears that the issue might be due to the default source name not matching the registered source name. What do you think?
https://github.com/hrsh7th/nvim-gtd/blob/b0c9d9a92478cfe2b39857ee497dee25534c8c9d/lua/gtd/init.lua#L52-L53